### PR TITLE
Fix expressions with different return type

### DIFF
--- a/expander/ppx_trace_expander.ml
+++ b/expander/ppx_trace_expander.ml
@@ -30,21 +30,6 @@ let ptyp_constr ~loc lid =
    ptyp_constr ~loc (Located.mk ~loc @@ lid) []
 
 
-let span_sig ~loc ~modul ?(name_label = "name") ?(code_path_label = "code_path")
-    ?(stdlib_name_label = "stdlib_name") () =
-   let loc = { loc with loc_ghost = true } in
-   let lstr label next =
-      ptyp_arrow (Labelled label) (ptyp_constr ~loc @@ Lident "string") ~loc next
-   in
-   let lcode_path label next =
-      ptyp_arrow (Labelled label)
-        (ptyp_constr ~loc @@ Ldot (modul, "code_path"))
-        ~loc next
-   in
-   lstr name_label @@ lcode_path code_path_label @@ lstr stdlib_name_label
-   @@ [%type: (unit -> 'ret) -> 'ret]
-
-
 let trace_syntax_sig ~loc =
    let loc = { loc with loc_ghost = true } in
    [%stri
@@ -90,12 +75,8 @@ let qualified_span ~modul ?(name_label = "name") ?(code_path_label = "code_path"
     (body : expression) =
    let loc = { body.pexp_loc with loc_ghost = true } in
    let thunk = [%expr fun () -> [%e body]] in
-   let constrained_ident =
-      pexp_constraint ~loc
-        (pexp_ident ~loc @@ Located.mk ~loc @@ Ldot (modul, "span"))
-        (span_sig ~loc ~modul ~name_label ~code_path_label ~stdlib_name_label ())
-   in
-   pexp_apply ~loc constrained_ident
+   pexp_apply ~loc
+     (pexp_ident ~loc @@ Located.mk ~loc @@ Ldot (modul, "span"))
      [
        (Labelled name_label, name);
        (Labelled code_path_label, code_path);

--- a/test/test_basic.ml
+++ b/test/test_basic.ml
@@ -1,3 +1,5 @@
+open Alcotest
+
 module Trace_syntax = struct
   type code_path = {
      file_path : string;
@@ -8,11 +10,19 @@ module Trace_syntax = struct
      value : string option;
    }
 
-  let span ~name ~code_path:_ ~stdlib_name:_ f =
-     let ret = f () in
-     String.concat " " [ ret; "-"; name; "got wrapped btw" ]
+  let span ~name:_ ~code_path:_ ~stdlib_name:_ f = f ()
 end
 
 let%span greet name = "Hello, " ^ name ^ "!"
 
 let run () = ()
+
+let test_basic =
+   test_case "Functions with different return types" `Quick (fun () ->
+       let%span greet name = "Hello, " ^ name ^ "!" in
+       let%span add x y = x + y in
+       let result = greet "Elliott" ^ " " ^ string_of_int (add 1 2) in
+       (check string) "" "Hello, Elliott! 3" result)
+
+
+let tests = [ ("basic", [ test_basic ]) ]

--- a/test/test_trace.ml
+++ b/test/test_trace.ml
@@ -4,6 +4,7 @@ let () = Test_basic.run ()
 
 let () =
    let tests =
-      List.flatten [ Test_trace_expression.tests; Test_trace_structure_item.tests ]
+      List.flatten
+        [ Test_trace_expression.tests; Test_trace_structure_item.tests; Test_basic.tests ]
    in
    run "Correct usage" tests


### PR DESCRIPTION
Fixes an issue where 2 expression couldn't return the same type

```ocaml
let%span fn1 input = Lwt.return (int_of_string input) in
let%span fn2 input = Lwt.return (string_of_int input) in
```

was giving:

```
869 |   let%span fn2 input = Lwt.return (string_of_int input) in
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type string Lwt.t
       but an expression was expected of type int Lwt.t
       Type string is not compatible with type int 
```